### PR TITLE
Fix build failures after kotlin-sdk upgrade to v0.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.3.10"
 ktor = "3.5.1"
 logback = "1.5.37"
 logging = "8.0.4"
-mcp = "0.8.4"
+mcp = "0.13.0"
 coroutines-test = "1.11.0"
 
 [libraries]

--- a/src/main/kotlin/mcp/MediaWikiMCPServer.kt
+++ b/src/main/kotlin/mcp/MediaWikiMCPServer.kt
@@ -16,7 +16,6 @@ import com.sriniketh.utils.EnvConfigProvider
 import com.sriniketh.utils.EnvConfigProviderImpl
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.Url
-import io.ktor.utils.io.streams.asInput
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -26,6 +25,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.Transport
 import kotlinx.io.asSink
+import kotlinx.io.asSource
 import kotlinx.io.buffered
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -120,12 +120,12 @@ class MediaWikiMCPServer(
         }
 
         logger.info { "Setting up transport and connecting server..." }
-        server.connect(transport)
+        server.createSession(transport)
         logger.info { "MediaWiki MCP Server connected and ready to handle requests" }
     }
 }
 
 private fun stdioServerTransport(): StdioServerTransport = StdioServerTransport(
-    System.`in`.asInput(),
+    System.`in`.asSource().buffered(),
     System.out.asSink().buffered()
 )

--- a/src/test/kotlin/fakes/FakeTransport.kt
+++ b/src/test/kotlin/fakes/FakeTransport.kt
@@ -28,7 +28,7 @@ class FakeTransport : Transport {
         isStarted = true
     }
 
-    override suspend fun send(message: JSONRPCMessage, requestOptions: TransportSendOptions?) {
+    override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
         if (isClosed) return
 
         linkedTransport?.let { linked ->

--- a/src/test/kotlin/mcp/MediaWikiMCPServerTest.kt
+++ b/src/test/kotlin/mcp/MediaWikiMCPServerTest.kt
@@ -75,9 +75,9 @@ class MediaWikiMCPServerTest {
                 }
             )
 
-            assertEquals(1, result!!.content.size)
+            assertEquals(1, result.content.size)
             val content = result.content[0] as TextContent
-            val responseJson = Json.parseToJsonElement(content.text!!).jsonObject
+            val responseJson = Json.parseToJsonElement(content.text).jsonObject
             assertTrue(responseJson.containsKey("search_results"))
 
             val searchResults = Json.decodeFromJsonElement<JsonObject>(responseJson["search_results"]!!)
@@ -110,9 +110,9 @@ class MediaWikiMCPServerTest {
                 }
             )
 
-            assertEquals(1, result!!.content.size)
+            assertEquals(1, result.content.size)
             val content = result.content[0] as TextContent
-            val responseJson = Json.parseToJsonElement(content.text!!).jsonObject
+            val responseJson = Json.parseToJsonElement(content.text).jsonObject
             assertTrue(responseJson.containsKey("error"))
 
             val errorMessage = responseJson["error"]!!.jsonPrimitive.content
@@ -140,9 +140,9 @@ class MediaWikiMCPServerTest {
                 }
             )
 
-            assertEquals(1, result!!.content.size)
+            assertEquals(1, result.content.size)
             val content = result.content[0] as TextContent
-            val responseJson = Json.parseToJsonElement(content.text!!).jsonObject
+            val responseJson = Json.parseToJsonElement(content.text).jsonObject
             assertTrue(responseJson.containsKey("page_content"))
 
             val pageContent = Json.decodeFromJsonElement<JsonObject>(responseJson["page_content"]!!)
@@ -168,9 +168,9 @@ class MediaWikiMCPServerTest {
                 }
             )
 
-            assertEquals(1, result!!.content.size)
+            assertEquals(1, result.content.size)
             val content = result.content[0] as TextContent
-            val responseJson = Json.parseToJsonElement(content.text!!).jsonObject
+            val responseJson = Json.parseToJsonElement(content.text).jsonObject
             assertTrue(responseJson.containsKey("error"))
 
             val errorMessage = responseJson["error"]!!.jsonPrimitive.content


### PR DESCRIPTION
## Summary

- Replaces deprecated `server.connect(transport)` with `server.createSession(transport)` (renamed in 0.9.0+)
- Replaces `InputStream.asInput()` (ktor) with `InputStream.asSource().buffered()` (kotlinx.io) for `StdioServerTransport` constructor
- Renames `FakeTransport.send()` parameter to `options` to match the updated `Transport` interface
- Removes unnecessary `!!` non-null assertions in tests (`callTool` and `TextContent.text` are now non-nullable in 0.13.0)

Fixes the build failure introduced by PR #57 (`kotlin-sdk` → v0.13.0).

## Test plan

- [x] `./gradlew build` passes locally with `mcp = "0.13.0"` in `libs.versions.toml`
- [x] All existing tests pass
- [x] No compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)